### PR TITLE
refactor: share chezmoi script and test helpers

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -80,6 +80,13 @@ jobs:
           template home/dot_local/bin/executable_update-matt-pocock-skills.tmpl > "$RUNNER_TEMP/update-matt-pocock-skills"
           template home/dot_local/bin/executable_verify-1password-setup.tmpl > "$RUNNER_TEMP/verify-1password-setup"
           template home/.chezmoitemplates/ubuntu-package-foundation.sh > "$RUNNER_TEMP/ubuntu-package-foundation.sh"
+          template home/.chezmoitemplates/atomic-json-state.py > "$RUNNER_TEMP/atomic-json-state.py"
+          template home/.chezmoitemplates/shell-foundation.sh > "$RUNNER_TEMP/shell-foundation.sh"
+          template home/.chezmoitemplates/gnome-settings-foundation.sh > "$RUNNER_TEMP/gnome-settings-foundation.sh"
+          shellcheck tests/test-helpers.sh
+          bash -n "$RUNNER_TEMP/shell-foundation.sh" "$RUNNER_TEMP/gnome-settings-foundation.sh"
+          shellcheck -s bash "$RUNNER_TEMP/shell-foundation.sh" "$RUNNER_TEMP/gnome-settings-foundation.sh"
+          python3 -m py_compile "$RUNNER_TEMP/atomic-json-state.py"
           bash -n "$RUNNER_TEMP/install-ubuntu-packages.sh"
           shellcheck "$RUNNER_TEMP/install-ubuntu-packages.sh"
           tests/test-install-ubuntu-packages.sh "$RUNNER_TEMP/install-ubuntu-packages.sh"
@@ -152,7 +159,7 @@ jobs:
           shellcheck "$RUNNER_TEMP/verify-1password-setup"
           tests/test-verify-1password-setup.sh "$RUNNER_TEMP/verify-1password-setup"
           tests/test-kubernetes-shell.sh "$RUNNER_TEMP/.zshrc" "$RUNNER_TEMP/.p10k.zsh"
-          tests/test-p10k-colors.sh "$RUNNER_TEMP/.p10k.zsh"
+          bash tests/test-p10k-colors.sh "$RUNNER_TEMP/.p10k.zsh"
           bash -n "$RUNNER_TEMP/ubuntu-package-foundation.sh"
           tests/test-ubuntu-package-foundation.sh "$RUNNER_TEMP/ubuntu-package-foundation.sh"
           tests/test-mise-config.sh home/dot_config/mise/config.toml

--- a/.scratch/dry-refactoring-wayfinder/issues/01-inventory-and-classify-shared-behavior.md
+++ b/.scratch/dry-refactoring-wayfinder/issues/01-inventory-and-classify-shared-behavior.md
@@ -1,0 +1,12 @@
+# Inventory and Classify Shared Behavior
+
+Type: research
+Status: resolved
+
+## Question
+
+Which duplicated behavior in the current chezmoi apply scripts and shell-test suite is a repository-wide policy or harness concern worth extracting, and which similar-looking code must remain local because its semantics differ?
+
+## Answer
+
+Extracted repository-wide shell policy into render-time fragments, shared JSON file safety into an embedded Python fragment, and test lifecycle/execution/assertion behavior into `tests/test-helpers.sh`. Domain-specific installation/configuration operations and command mocks remain local.

--- a/.scratch/dry-refactoring-wayfinder/issues/02-define-apply-fragment-contracts.md
+++ b/.scratch/dry-refactoring-wayfinder/issues/02-define-apply-fragment-contracts.md
@@ -1,0 +1,13 @@
+# Define Apply-Time Fragment Contracts
+
+Type: grilling
+Status: resolved
+Blocked by: 01
+
+## Question
+
+What exact render-time shell fragments should be introduced under `home/.chezmoitemplates/`, what inputs and side effects does each contract permit, and how will inclusion preserve standalone rendered apply scripts and shellcheckability?
+
+## Answer
+
+`shell-foundation.sh` provides `fail`, required-command checks, and warning-based command skips. `gnome-settings-foundation.sh` provides GNOME-session gating and idempotent `gsettings` writes. Both are included at render time, and each rendered apply script remains standalone with no source-tree runtime dependency.

--- a/.scratch/dry-refactoring-wayfinder/issues/03-define-safe-json-file-mechanics.md
+++ b/.scratch/dry-refactoring-wayfinder/issues/03-define-safe-json-file-mechanics.md
@@ -1,0 +1,13 @@
+# Define Safe JSON File Mechanics
+
+Type: grilling
+Status: resolved
+Blocked by: 01
+
+## Question
+
+What reusable render-time fragment or embedded utility contract should cover symlink protection, permissions, bounded backups, atomic replacement, and cleanup for JSON state files while leaving Chrome, Slack, and Obsidian schema mutations independent?
+
+## Answer
+
+`atomic-json-state.py` provides parameterized JSON-object loading and atomic writing with symlink protection, preserved/default permissions, bounded three-file backups, fsync plus replace, and temporary-file cleanup. Chrome, Slack, Obsidian, and VS Code retain their own schema mutation logic.

--- a/.scratch/dry-refactoring-wayfinder/issues/04-define-test-library-contract.md
+++ b/.scratch/dry-refactoring-wayfinder/issues/04-define-test-library-contract.md
@@ -1,0 +1,13 @@
+# Define Test Library Contract
+
+Type: grilling
+Status: resolved
+Blocked by: 01
+
+## Question
+
+What API and fixture conventions should the repository-local shell test library provide for argument validation, temporary roots, cleanup, rendered-script execution, and common assertions, and which command mocks must remain test-specific?
+
+## Answer
+
+`tests/test-helpers.sh` provides `test_require_args`, `test_setup`, `test_run_script`, and `test_assert_file_contains`. Tests use the shared argument/temp lifecycle and keep application-specific command mocks, fixtures, and process behavior local.

--- a/.scratch/dry-refactoring-wayfinder/issues/05-plan-migration-and-ci-slices.md
+++ b/.scratch/dry-refactoring-wayfinder/issues/05-plan-migration-and-ci-slices.md
@@ -1,0 +1,13 @@
+# Plan Migration and CI Slices
+
+Type: grilling
+Status: resolved
+Blocked by: 02, 03, 04
+
+## Question
+
+In what order should the shared fragments and test library be introduced and adopted by script families, and what exact `.github/workflows/validate.yml` changes keep rendered output, `bash -n`, `shellcheck`, focused tests, and chezmoi dry-run verification as enforceable gates throughout the migration?
+
+## Answer
+
+The implementation introduced shell fragments first, migrated JSON consumers second, and migrated the shell-test suite third. CI now renders and validates the atomic Python fragment, shell-checks the test helper, keeps rendered-script syntax and focused tests, and invokes non-executable static tests through `bash`; local verification also runs chezmoi dry-run and `verify --exclude scripts`.

--- a/.scratch/dry-refactoring-wayfinder/map.md
+++ b/.scratch/dry-refactoring-wayfinder/map.md
@@ -1,0 +1,39 @@
+# DRY Refactoring Map
+
+## Destination
+
+An implementation-ready refactoring plan for reducing duplicated cross-cutting behavior in the chezmoi source state and its shell-test suite, with explicit helper contracts, migration order, and verification criteria.
+
+## Notes
+
+Domain: the single-context Dotfiles repository and its managed Ubuntu desktop environment.
+
+Consult the `chezmoi`, `domain-modeling`, and `grilling` skills when working tickets. Preserve chezmoi's standalone rendered apply scripts: source-state fragments are included at render time, while test helpers are sourced only by repository tests.
+
+Standing decisions from charting:
+
+- Cover both apply scripts and tests, but extract repository-wide policies and test-harness behavior rather than domain-specific operations.
+- Use small semantic fragments with explicit contracts, not one universal shell library.
+- Share safe JSON file mechanics while keeping application-specific schema mutation local.
+- Preserve behavior and keep rendered scripts as the primary test boundary.
+- Migrate incrementally and update CI alongside each migration; no compatibility shims are required for internal helper names.
+
+## Decisions so far
+
+<!-- Closed child tickets are appended here as they resolve. -->
+
+- [Inventory and Classify Shared Behavior](issues/01-inventory-and-classify-shared-behavior.md) — Extracted generic shell policy, GNOME settings policy, atomic JSON file safety, and test lifecycle seams; kept domain operations and mocks local.
+- [Define Apply-Time Fragment Contracts](issues/02-define-apply-fragment-contracts.md) — Render-time `shell-foundation.sh` and `gnome-settings-foundation.sh` fragments preserve standalone scripts and shellcheckable output.
+- [Define Safe JSON File Mechanics](issues/03-define-safe-json-file-mechanics.md) — `atomic-json-state.py` now centralizes symlink checks, JSON loading, permissions, bounded backups, atomic replacement, and cleanup for four application state consumers.
+- [Define Test Library Contract](issues/04-define-test-library-contract.md) — `tests/test-helpers.sh` owns argument validation, temporary roots, rendered-script execution, and file-content assertions; command mocks remain local.
+- [Plan Migration and CI Slices](issues/05-plan-migration-and-ci-slices.md) — The migration is complete in semantic slices, with rendering, syntax, shellcheck, Python compilation, focused tests, and chezmoi verification retained as gates.
+
+## Not yet specified
+
+<!-- No in-scope decisions remain unspecified for this implementation. -->
+
+## Out of scope
+
+- Refactoring domain-specific installation or configuration operations merely because they use similar shell syntax.
+- Sharing application-specific JSON schema mutations between Chrome, Slack, and Obsidian.
+- Introducing runtime dependencies on the chezmoi source tree or a generated helper file.

--- a/home/.chezmoiscripts/run_always_after_22-configure-repository-workspace.sh.tmpl
+++ b/home/.chezmoiscripts/run_always_after_22-configure-repository-workspace.sh.tmpl
@@ -3,17 +3,11 @@
 
 set -euo pipefail
 
-fail() {
-  printf 'error: %s\n' "$*" >&2
-  exit 1
-}
+{{ template "shell-foundation.sh" . }}
 
-command -v code >/dev/null 2>&1 ||
-  fail "VS Code is unavailable; install VS Code Stable before configuring the repository workspace"
-command -v pgrep >/dev/null 2>&1 ||
-  fail "pgrep is unavailable; cannot safely update VS Code workspace trust"
-command -v python3 >/dev/null 2>&1 ||
-  fail "python3 is unavailable; cannot update VS Code workspace trust"
+require_command code "VS Code is unavailable; install VS Code Stable before configuring the repository workspace"
+require_command pgrep "pgrep is unavailable; cannot safely update VS Code workspace trust"
+require_command python3 "python3 is unavailable; cannot update VS Code workspace trust"
 
 if pgrep -x code >/dev/null 2>&1; then
   fail "VS Code is running; close it and rerun chezmoi apply before configuring workspace trust"
@@ -21,42 +15,24 @@ fi
 
 repository_namespace="$HOME/repos/github/stefan-karlsson"
 storage_file="${XDG_CONFIG_HOME:-$HOME/.config}/Code/User/globalStorage/storage.json"
-backup_prefix="${storage_file}.chezmoi-backup."
 
 install -d -m 0755 "$repository_namespace"
 
-python3 - "$storage_file" "$repository_namespace" "$backup_prefix" <<'PY'
-import glob
-import json
-import os
-import shutil
-import stat
-import sys
-import tempfile
-from datetime import datetime, timezone
+python3 - "$storage_file" "$repository_namespace" <<'PY'
+{{ template "atomic-json-state.py" . }}
 
-storage_path, repository_namespace, backup_prefix = sys.argv[1:]
+storage_path, repository_namespace = sys.argv[1:]
 storage_directory = os.path.dirname(storage_path)
 storage_key = "content.trust.model.key"
 
 os.makedirs(storage_directory, mode=0o755, exist_ok=True)
 
-if os.path.lexists(storage_path) and os.path.islink(storage_path):
-    raise SystemExit(f"error: VS Code storage file is a symlink: {storage_path}")
-
-if os.path.exists(storage_path):
-    try:
-        with open(storage_path, encoding="utf-8") as storage_file:
-            storage = json.load(storage_file)
-    except (OSError, json.JSONDecodeError) as error:
-        raise SystemExit(f"error: cannot read VS Code storage file: {error}") from error
-    storage_mode = stat.S_IMODE(os.stat(storage_path).st_mode)
-else:
-    storage = {}
-    storage_mode = 0o600
-
-if not isinstance(storage, dict):
-    raise SystemExit("error: VS Code storage file does not contain a JSON object")
+storage, storage_mode = read_json_object(
+  storage_path,
+  symlink_label="VS Code storage file",
+  read_context="VS Code storage file",
+  object_error="error: VS Code storage file does not contain a JSON object",
+)
 
 raw_trust = storage.get(storage_key)
 if raw_trust is None:
@@ -104,42 +80,14 @@ if not changed and os.path.exists(storage_path):
     raise SystemExit(0)
 
 storage[storage_key] = json.dumps(trust, separators=(",", ":"), ensure_ascii=False)
-
-if os.path.exists(storage_path):
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-    backup_path = f"{backup_prefix}{timestamp}"
-    suffix = 1
-    while os.path.exists(backup_path):
-        backup_path = f"{backup_prefix}{timestamp}-{suffix}"
-        suffix += 1
-    shutil.copyfile(storage_path, backup_path)
-    os.chmod(backup_path, storage_mode)
-
-temporary_path = None
-try:
-    descriptor, temporary_path = tempfile.mkstemp(prefix=".storage.json.chezmoi-", dir=storage_directory)
-    with os.fdopen(descriptor, "w", encoding="utf-8") as temporary_file:
-        json.dump(storage, temporary_file, indent=4, ensure_ascii=False)
-        temporary_file.write("\n")
-        temporary_file.flush()
-        os.fsync(temporary_file.fileno())
-    os.chmod(temporary_path, storage_mode)
-    os.replace(temporary_path, storage_path)
-except OSError as error:
-    if temporary_path is not None:
-        try:
-            os.unlink(temporary_path)
-        except FileNotFoundError:
-            pass
-    raise SystemExit(f"error: cannot update VS Code storage file: {error}") from error
-
-backups = sorted(
-    glob.glob(f"{backup_prefix}*"),
-    key=os.path.getmtime,
-    reverse=True,
+write_json_object(
+  storage_path,
+  storage,
+  mode=storage_mode,
+  prefix=".storage.json.chezmoi-",
+  update_context="VS Code storage file",
+  indent=4,
 )
-for old_backup in backups[3:]:
-    os.unlink(old_backup)
 
 print(f"Configured VS Code trust for {repository_namespace}")
 PY

--- a/home/.chezmoiscripts/run_always_after_24-configure-google-chrome-theme.sh.tmpl
+++ b/home/.chezmoiscripts/run_always_after_24-configure-google-chrome-theme.sh.tmpl
@@ -3,24 +3,17 @@
 
 set -euo pipefail
 
-fail() {
-  printf 'error: %s\n' "$*" >&2
-  exit 1
-}
+{{ template "shell-foundation.sh" . }}
 
 chrome_theme_id="gfapcejdoghpoidkfodoiiffaaibpaem"
 chrome_config_dir="${CHROME_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/google-chrome}"
 external_extensions_dir="${CHROME_EXTERNAL_EXTENSIONS_DIR:-/opt/google/chrome/extensions}"
 external_extension_file="${external_extensions_dir}/${chrome_theme_id}.json"
 
-command -v sudo >/dev/null 2>&1 ||
-  fail "sudo is unavailable; Chrome's supported Linux external-extension directory requires administrator access"
-command -v python3 >/dev/null 2>&1 ||
-  fail "python3 is unavailable; cannot update Chrome profile preferences"
-command -v ps >/dev/null 2>&1 ||
-  fail "ps is unavailable; cannot safely update Chrome profile preferences"
-command -v awk >/dev/null 2>&1 ||
-  fail "awk is unavailable; cannot safely update Chrome profile preferences"
+require_command sudo "sudo is unavailable; Chrome's supported Linux external-extension directory requires administrator access"
+require_command python3 "python3 is unavailable; cannot update Chrome profile preferences"
+require_command ps "ps is unavailable; cannot safely update Chrome profile preferences"
+require_command awk "awk is unavailable; cannot safely update Chrome profile preferences"
 
 if ! command -v google-chrome >/dev/null 2>&1 && ! command -v google-chrome-stable >/dev/null 2>&1; then
   fail "Google Chrome Stable is unavailable; install it before configuring the Dracula theme"
@@ -63,28 +56,16 @@ for preferences in "${preference_files[@]}"; do
   esac
 
   python3 - "${preferences}" "${chrome_theme_id}" <<'PY'
-import json
-import glob
-import os
-import shutil
-import stat
 import sys
-import tempfile
-from datetime import datetime, timezone
+{{ template "atomic-json-state.py" . }}
 
 preferences_path, theme_id = sys.argv[1:]
-
-if os.path.islink(preferences_path):
-    raise SystemExit(f"error: Chrome preferences file is a symlink: {preferences_path}")
-
-try:
-    with open(preferences_path, encoding="utf-8") as preferences_file:
-        preferences = json.load(preferences_file)
-except (OSError, json.JSONDecodeError) as error:
-    raise SystemExit(f"error: cannot read Chrome preferences {preferences_path}: {error}") from error
-
-if not isinstance(preferences, dict):
-    raise SystemExit(f"error: Chrome preferences are not a JSON object: {preferences_path}")
+preferences, preferences_mode = read_json_object(
+    preferences_path,
+    symlink_label="Chrome preferences file",
+    read_context=f"Chrome preferences {preferences_path}",
+    object_error=f"error: Chrome preferences are not a JSON object: {preferences_path}",
+)
 
 extensions = preferences.setdefault("extensions", {})
 if not isinstance(extensions, dict):
@@ -102,46 +83,17 @@ if not changed:
     print(f"Chrome profile already uses Dracula: {preferences_path}")
     raise SystemExit(0)
 
-preferences_directory = os.path.dirname(preferences_path)
-preferences_mode = stat.S_IMODE(os.stat(preferences_path).st_mode)
-timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-backup_path = f"{preferences_path}.chezmoi-backup.{timestamp}"
-suffix = 1
-while os.path.exists(backup_path):
-    backup_path = f"{preferences_path}.chezmoi-backup.{timestamp}-{suffix}"
-    suffix += 1
-shutil.copyfile(preferences_path, backup_path)
-os.chmod(backup_path, preferences_mode)
-
-temporary_path = None
-try:
-    descriptor, temporary_path = tempfile.mkstemp(
-        prefix=".Preferences.chezmoi-", dir=preferences_directory
-    )
-    with os.fdopen(descriptor, "w", encoding="utf-8") as temporary_file:
-        json.dump(preferences, temporary_file, separators=(",", ":"), ensure_ascii=False)
-        temporary_file.write("\n")
-        temporary_file.flush()
-        os.fsync(temporary_file.fileno())
-    os.chmod(temporary_path, preferences_mode)
-    os.replace(temporary_path, preferences_path)
-except OSError as error:
-    if temporary_path is not None:
-        try:
-            os.unlink(temporary_path)
-        except FileNotFoundError:
-            pass
-    raise SystemExit(f"error: cannot update Chrome preferences {preferences_path}: {error}") from error
+write_json_object(
+    preferences_path,
+    preferences,
+    mode=preferences_mode,
+    prefix=".Preferences.chezmoi-",
+    update_context=f"Chrome preferences {preferences_path}",
+    separators=(",", ":"),
+)
 
 print(f"Configured Dracula Chrome theme in {preferences_path}")
 
-backups = sorted(
-    glob.glob(f"{preferences_path}.chezmoi-backup.*"),
-    key=os.path.getmtime,
-    reverse=True,
-)
-for old_backup in backups[3:]:
-    os.unlink(old_backup)
 PY
   profile_count=$((profile_count + 1))
 done

--- a/home/.chezmoiscripts/run_always_after_25-configure-slack-theme.sh.tmpl
+++ b/home/.chezmoiscripts/run_always_after_25-configure-slack-theme.sh.tmpl
@@ -3,14 +3,11 @@
 
 set -euo pipefail
 
-fail() {
-  printf 'error: %s\n' "$*" >&2
-  exit 1
-}
+{{ template "shell-foundation.sh" . }}
 
-command -v python3 >/dev/null 2>&1 || fail "python3 is unavailable; cannot update Slack theme state"
-command -v ps >/dev/null 2>&1 || fail "ps is unavailable; cannot safely update Slack state"
-command -v awk >/dev/null 2>&1 || fail "awk is unavailable; cannot safely update Slack state"
+require_command python3 "python3 is unavailable; cannot update Slack theme state"
+require_command ps "ps is unavailable; cannot safely update Slack state"
+require_command awk "awk is unavailable; cannot safely update Slack state"
 
 running_slack_pids="$(ps -eo pid=,comm= | awk '$2 == "slack" { print $1 }')"
 [[ -z "${running_slack_pids}" ]] ||
@@ -23,25 +20,15 @@ if [[ ! -f "${slack_state_file}" ]]; then
 fi
 
 python3 - "${slack_state_file}" <<'PY'
-import glob
-import json
-import os
-import shutil
-import stat
-import sys
-import tempfile
-from datetime import datetime, timezone
+{{ template "atomic-json-state.py" . }}
 
 state_path = sys.argv[1]
-if os.path.islink(state_path):
-    raise SystemExit(f"error: Slack root state is a symlink: {state_path}")
-try:
-    with open(state_path, encoding="utf-8") as state_file:
-        state = json.load(state_file)
-except (OSError, json.JSONDecodeError) as error:
-    raise SystemExit(f"error: cannot read Slack root state: {error}") from error
-if not isinstance(state, dict):
-    raise SystemExit("error: Slack root state is not a JSON object")
+state, mode = read_json_object(
+    state_path,
+    symlink_label="Slack root state",
+    read_context="Slack root state",
+    object_error="error: Slack root state is not a JSON object",
+)
 
 settings = state.setdefault("settings", {})
 webapp = state.setdefault("webapp", {})
@@ -67,37 +54,14 @@ if not changed:
     print(f"Slack already uses Dracula dark mode: {state_path}")
     raise SystemExit(0)
 
-mode = stat.S_IMODE(os.stat(state_path).st_mode)
-timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-backup_path = f"{state_path}.chezmoi-backup.{timestamp}"
-suffix = 1
-while os.path.exists(backup_path):
-    backup_path = f"{state_path}.chezmoi-backup.{timestamp}-{suffix}"
-    suffix += 1
-shutil.copyfile(state_path, backup_path)
-os.chmod(backup_path, mode)
-
-temporary_path = None
-try:
-    descriptor, temporary_path = tempfile.mkstemp(prefix=".root-state.chezmoi-", dir=os.path.dirname(state_path))
-    with os.fdopen(descriptor, "w", encoding="utf-8") as temporary_file:
-        json.dump(state, temporary_file, indent=2, ensure_ascii=False)
-        temporary_file.write("\n")
-        temporary_file.flush()
-        os.fsync(temporary_file.fileno())
-    os.chmod(temporary_path, mode)
-    os.replace(temporary_path, state_path)
-except OSError as error:
-    if temporary_path is not None:
-        try:
-            os.unlink(temporary_path)
-        except FileNotFoundError:
-            pass
-    raise SystemExit(f"error: cannot update Slack root state: {error}") from error
-
-backups = sorted(glob.glob(f"{state_path}.chezmoi-backup.*"), key=os.path.getmtime, reverse=True)
-for old_backup in backups[3:]:
-    os.unlink(old_backup)
+write_json_object(
+    state_path,
+    state,
+    mode=mode,
+    prefix=".root-state.chezmoi-",
+    update_context="Slack root state",
+    indent=2,
+)
 print(f"Configured Dracula dark mode in Slack: {state_path}")
 PY
 {{- end }}

--- a/home/.chezmoiscripts/run_always_after_26-configure-obsidian-theme.sh.tmpl
+++ b/home/.chezmoiscripts/run_always_after_26-configure-obsidian-theme.sh.tmpl
@@ -3,15 +3,12 @@
 
 set -euo pipefail
 
-fail() {
-  printf 'error: %s\n' "$*" >&2
-  exit 1
-}
+{{ template "shell-foundation.sh" . }}
 
-command -v python3 >/dev/null 2>&1 || fail "python3 is unavailable; cannot update Obsidian theme state"
-command -v git >/dev/null 2>&1 || fail "git is unavailable; cannot install the official Dracula Obsidian theme"
-command -v ps >/dev/null 2>&1 || fail "ps is unavailable; cannot safely update Obsidian state"
-command -v awk >/dev/null 2>&1 || fail "awk is unavailable; cannot safely update Obsidian state"
+require_command python3 "python3 is unavailable; cannot update Obsidian theme state"
+require_command git "git is unavailable; cannot install the official Dracula Obsidian theme"
+require_command ps "ps is unavailable; cannot safely update Obsidian state"
+require_command awk "awk is unavailable; cannot safely update Obsidian state"
 
 running_obsidian_pids="$(ps -eo pid=,comm= | awk '$2 == "obsidian" || $2 == "Obsidian" { print $1 }')"
 [[ -z "${running_obsidian_pids}" ]] ||
@@ -42,68 +39,29 @@ while IFS= read -r obsidian_config_dir; do
   fi
 
   python3 - "${appearance_file}" <<'PY'
-import glob
-import json
-import os
-import shutil
-import stat
-import sys
-import tempfile
-from datetime import datetime, timezone
+{{ template "atomic-json-state.py" . }}
 
 appearance_path = sys.argv[1]
-if os.path.lexists(appearance_path) and os.path.islink(appearance_path):
-    raise SystemExit(f"error: Obsidian appearance file is a symlink: {appearance_path}")
-if os.path.exists(appearance_path):
-    try:
-        with open(appearance_path, encoding="utf-8") as appearance_file:
-            appearance = json.load(appearance_file)
-    except (OSError, json.JSONDecodeError) as error:
-        raise SystemExit(f"error: cannot read Obsidian appearance file: {error}") from error
-    mode = stat.S_IMODE(os.stat(appearance_path).st_mode)
-else:
-    appearance = {}
-    mode = 0o600
-if not isinstance(appearance, dict):
-    raise SystemExit(f"error: Obsidian appearance file is not a JSON object: {appearance_path}")
+appearance, mode = read_json_object(
+    appearance_path,
+    symlink_label="Obsidian appearance file",
+    read_context="Obsidian appearance file",
+    object_error=f"error: Obsidian appearance file is not a JSON object: {appearance_path}",
+)
 if appearance.get("cssTheme") == "Dracula Official":
     print(f"Obsidian already uses Dracula: {appearance_path}")
     raise SystemExit(0)
 
 appearance["cssTheme"] = "Dracula Official"
-appearance_directory = os.path.dirname(appearance_path)
-os.makedirs(appearance_directory, mode=0o755, exist_ok=True)
-if os.path.exists(appearance_path):
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-    backup_path = f"{appearance_path}.chezmoi-backup.{timestamp}"
-    suffix = 1
-    while os.path.exists(backup_path):
-        backup_path = f"{appearance_path}.chezmoi-backup.{timestamp}-{suffix}"
-        suffix += 1
-    shutil.copyfile(appearance_path, backup_path)
-    os.chmod(backup_path, mode)
+write_json_object(
+    appearance_path,
+    appearance,
+    mode=mode,
+    prefix=".appearance.chezmoi-",
+    update_context="Obsidian appearance file",
+    indent=2,
+)
 
-temporary_path = None
-try:
-    descriptor, temporary_path = tempfile.mkstemp(prefix=".appearance.chezmoi-", dir=appearance_directory)
-    with os.fdopen(descriptor, "w", encoding="utf-8") as temporary_file:
-        json.dump(appearance, temporary_file, indent=2, ensure_ascii=False)
-        temporary_file.write("\n")
-        temporary_file.flush()
-        os.fsync(temporary_file.fileno())
-    os.chmod(temporary_path, mode)
-    os.replace(temporary_path, appearance_path)
-except OSError as error:
-    if temporary_path is not None:
-        try:
-            os.unlink(temporary_path)
-        except FileNotFoundError:
-            pass
-    raise SystemExit(f"error: cannot update Obsidian appearance file: {error}") from error
-
-backups = sorted(glob.glob(f"{appearance_path}.chezmoi-backup.*"), key=os.path.getmtime, reverse=True)
-for old_backup in backups[3:]:
-    os.unlink(old_backup)
 print(f"Configured Dracula theme in Obsidian: {appearance_path}")
 PY
 done < <(

--- a/home/.chezmoiscripts/run_always_after_27-install-gnome-shell-extensions.sh.tmpl
+++ b/home/.chezmoiscripts/run_always_after_27-install-gnome-shell-extensions.sh.tmpl
@@ -3,21 +3,15 @@
 
 set -euo pipefail
 
-case ":${XDG_CURRENT_DESKTOP:-}${DESKTOP_SESSION:-}": in
-  *[Gg][Nn][Oo][Mm][Ee]*) ;;
-  *) exit 0 ;;
-esac
+{{ template "shell-foundation.sh" . }}
+{{ template "gnome-settings-foundation.sh" . }}
+require_gnome_session
 
-fail() {
-  printf 'error: %s\n' "$*" >&2
-  exit 1
-}
-
-command -v curl >/dev/null 2>&1 || fail "curl is required to install GNOME Shell extensions"
-command -v jq >/dev/null 2>&1 || fail "jq is required to select compatible GNOME Shell extension releases"
-command -v gnome-shell >/dev/null 2>&1 || fail "gnome-shell is required to install GNOME Shell extensions"
-command -v gnome-extensions >/dev/null 2>&1 || fail "gnome-extensions is required to install GNOME Shell extensions"
-command -v gsettings >/dev/null 2>&1 || fail "gsettings is required to enable GNOME Shell extensions"
+require_command curl "curl is required to install GNOME Shell extensions"
+require_command jq "jq is required to select compatible GNOME Shell extension releases"
+require_command gnome-shell "gnome-shell is required to install GNOME Shell extensions"
+require_command gnome-extensions "gnome-extensions is required to install GNOME Shell extensions"
+require_command gsettings "gsettings is required to enable GNOME Shell extensions"
 
 shell_version="$(gnome-shell --version | sed -n 's/.* \([0-9][0-9.]*\)$/\1/p')"
 [[ -n "${shell_version}" ]] || fail "could not determine the GNOME Shell version"

--- a/home/.chezmoiscripts/run_always_after_28-configure-dash-to-dock.sh.tmpl
+++ b/home/.chezmoiscripts/run_always_after_28-configure-dash-to-dock.sh.tmpl
@@ -3,15 +3,10 @@
 
 set -euo pipefail
 
-case ":${XDG_CURRENT_DESKTOP:-}${DESKTOP_SESSION:-}": in
-  *[Gg][Nn][Oo][Mm][Ee]*) ;;
-  *) exit 0 ;;
-esac
-
-command -v gsettings >/dev/null 2>&1 || {
-  printf 'warning: gsettings is unavailable; skipping Dash to Dock preferences\n' >&2
-  exit 0
-}
+{{ template "shell-foundation.sh" . }}
+{{ template "gnome-settings-foundation.sh" . }}
+require_gnome_session
+skip_without_command gsettings "gsettings is unavailable; skipping Dash to Dock preferences"
 
 schema='org.gnome.shell.extensions.dash-to-dock'
 if ! gsettings writable "${schema}" dash-max-icon-size >/dev/null 2>&1 ||
@@ -20,11 +15,6 @@ if ! gsettings writable "${schema}" dash-max-icon-size >/dev/null 2>&1 ||
   exit 0
 fi
 
-if [[ "$(gsettings get "${schema}" dash-max-icon-size)" != '32' ]]; then
-  gsettings set "${schema}" dash-max-icon-size 32
-fi
-
-if [[ "$(gsettings get "${schema}" extend-height)" != 'false' ]]; then
-  gsettings set "${schema}" extend-height false
-fi
+set_gsetting_if_changed "${schema}" dash-max-icon-size 32 '32'
+set_gsetting_if_changed "${schema}" extend-height false 'false'
 {{- end }}

--- a/home/.chezmoiscripts/run_always_after_28-configure-vitals.sh.tmpl
+++ b/home/.chezmoiscripts/run_always_after_28-configure-vitals.sh.tmpl
@@ -3,15 +3,10 @@
 
 set -euo pipefail
 
-case ":${XDG_CURRENT_DESKTOP:-}${DESKTOP_SESSION:-}": in
-  *[Gg][Nn][Oo][Mm][Ee]*) ;;
-  *) exit 0 ;;
-esac
-
-command -v gsettings >/dev/null 2>&1 || {
-  printf 'warning: gsettings is unavailable; skipping Vitals preferences\n' >&2
-  exit 0
-}
+{{ template "shell-foundation.sh" . }}
+{{ template "gnome-settings-foundation.sh" . }}
+require_gnome_session
+skip_without_command gsettings "gsettings is unavailable; skipping Vitals preferences"
 
 schema='org.gnome.shell.extensions.vitals'
 schema_dir="${XDG_DATA_HOME:-$HOME/.local/share}/gnome-shell/extensions/Vitals@CoreCoding.com/schemas"
@@ -28,11 +23,6 @@ if ! gsettings writable "${schema}" hot-sensors >/dev/null 2>&1 ||
 fi
 
 desired_hot_sensors="['_memory_usage_', '_system_load_1m_', '__network-rx_max__']"
-if [[ "$(gsettings get "${schema}" hot-sensors)" != "${desired_hot_sensors}" ]]; then
-  gsettings set "${schema}" hot-sensors "${desired_hot_sensors}"
-fi
-
-if [[ "$(gsettings get "${schema}" position-in-panel)" != '2' ]]; then
-  gsettings set "${schema}" position-in-panel 2
-fi
+set_gsetting_if_changed "${schema}" hot-sensors "${desired_hot_sensors}" "${desired_hot_sensors}"
+set_gsetting_if_changed "${schema}" position-in-panel 2 '2'
 {{- end }}

--- a/home/.chezmoiscripts/run_always_after_29-configure-gnome-favorites.sh.tmpl
+++ b/home/.chezmoiscripts/run_always_after_29-configure-gnome-favorites.sh.tmpl
@@ -3,19 +3,11 @@
 
 set -euo pipefail
 
-case ":${XDG_CURRENT_DESKTOP:-}${DESKTOP_SESSION:-}": in
-  *[Gg][Nn][Oo][Mm][Ee]*) ;;
-  *) exit 0 ;;
-esac
-
-command -v gsettings >/dev/null 2>&1 || {
-  printf 'warning: gsettings is unavailable; skipping GNOME favorites\n' >&2
-  exit 0
-}
-command -v python3 >/dev/null 2>&1 || {
-  printf 'warning: python3 is unavailable; skipping GNOME favorites\n' >&2
-  exit 0
-}
+{{ template "shell-foundation.sh" . }}
+{{ template "gnome-settings-foundation.sh" . }}
+require_gnome_session
+skip_without_command gsettings "gsettings is unavailable; skipping GNOME favorites"
+skip_without_command python3 "python3 is unavailable; skipping GNOME favorites"
 
 schema='org.gnome.shell'
 key='favorite-apps'

--- a/home/.chezmoiscripts/run_always_after_29-configure-live-lock-screen.sh.tmpl
+++ b/home/.chezmoiscripts/run_always_after_29-configure-live-lock-screen.sh.tmpl
@@ -3,25 +3,13 @@
 
 set -euo pipefail
 
-case ":${XDG_CURRENT_DESKTOP:-}${DESKTOP_SESSION:-}": in
-  *[Gg][Nn][Oo][Mm][Ee]*) ;;
-  *) exit 0 ;;
-esac
+{{ template "shell-foundation.sh" . }}
+{{ template "gnome-settings-foundation.sh" . }}
+require_gnome_session
+skip_without_command gsettings "gsettings is unavailable; skipping Live Lock Screen configuration"
 
-command -v gsettings >/dev/null 2>&1 || {
-  printf 'warning: gsettings is unavailable; skipping Live Lock Screen configuration\n' >&2
-  exit 0
-}
-
-command -v curl >/dev/null 2>&1 || {
-  printf 'warning: curl is unavailable; skipping Live Lock Screen animation download\n' >&2
-  exit 0
-}
-
-command -v sha256sum >/dev/null 2>&1 || {
-  printf 'warning: sha256sum is unavailable; skipping Live Lock Screen animation download\n' >&2
-  exit 0
-}
+skip_without_command curl "curl is unavailable; skipping Live Lock Screen animation download"
+skip_without_command sha256sum "sha256sum is unavailable; skipping Live Lock Screen animation download"
 
 schema='org.gnome.shell.extensions.live-lockscreen'
 schema_dir="${XDG_DATA_HOME:-$HOME/.local/share}/gnome-shell/extensions/live-lockscreen@nick-redwill/schemas"
@@ -64,23 +52,13 @@ if ! gsettings writable "${schema}" background-video-path >/dev/null 2>&1 ||
   exit 0
 fi
 
-set_setting() {
-  local key="$1"
-  local value="$2"
-  local expected="$3"
-
-  if [[ "$(gsettings get "${schema}" "${key}")" != "${expected}" ]]; then
-    gsettings set "${schema}" "${key}" "${value}"
-  fi
-}
-
-set_setting background-video-path "${animation_path}" "'${animation_path}'"
+set_gsetting_if_changed "${schema}" background-video-path "${animation_path}" "'${animation_path}'"
 # Preserve the animation's 16:9 aspect ratio while filling the lock screen.
-set_setting background-video-scaling-mode 2 '2'
-set_setting background-video-looped true 'true'
-set_setting background-audio-volume 0 '0'
-set_setting background-fade-in-duration 800 '800'
-set_setting prompt-change-blur true 'true'
-set_setting prompt-blur-radius 20 '20'
-set_setting prompt-blur-brightness 0.55 '0.55'
+set_gsetting_if_changed "${schema}" background-video-scaling-mode 2 '2'
+set_gsetting_if_changed "${schema}" background-video-looped true 'true'
+set_gsetting_if_changed "${schema}" background-audio-volume 0 '0'
+set_gsetting_if_changed "${schema}" background-fade-in-duration 800 '800'
+set_gsetting_if_changed "${schema}" prompt-change-blur true 'true'
+set_gsetting_if_changed "${schema}" prompt-blur-radius 20 '20'
+set_gsetting_if_changed "${schema}" prompt-blur-brightness 0.55 '0.55'
 {{- end }}

--- a/home/.chezmoiscripts/run_onchange_after_05-ensure-sudo-group.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_05-ensure-sudo-group.sh.tmpl
@@ -3,14 +3,11 @@
 
 set -euo pipefail
 
-fail() {
-  printf 'error: %s\n' "$*" >&2
-  exit 1
-}
+{{ template "shell-foundation.sh" . }}
 
-command -v sudo >/dev/null 2>&1 || fail "sudo is unavailable; install it before applying the dotfiles"
-command -v getent >/dev/null 2>&1 || fail "getent is unavailable; install it before applying the dotfiles"
-command -v usermod >/dev/null 2>&1 || fail "usermod is unavailable; install it before applying the dotfiles"
+require_command sudo "sudo is unavailable; install it before applying the dotfiles"
+require_command getent "getent is unavailable; install it before applying the dotfiles"
+require_command usermod "usermod is unavailable; install it before applying the dotfiles"
 
 login_user="${SUDO_USER:-$(id -un)}"
 sudo -v || fail "${login_user} cannot currently use sudo; use an existing administrator account or Ubuntu recovery/root access to add ${login_user} to the sudo group, sign out and back in, then reapply the dotfiles"

--- a/home/.chezmoiscripts/run_onchange_after_16-configure-docker.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_16-configure-docker.sh.tmpl
@@ -3,12 +3,9 @@
 
 set -euo pipefail
 
-fail() {
-  printf 'error: %s\n' "$*" >&2
-  exit 1
-}
+{{ template "shell-foundation.sh" . }}
 
-command -v docker >/dev/null 2>&1 || fail "Docker Engine is unavailable after package installation"
+require_command docker "Docker Engine is unavailable after package installation"
 getent group docker >/dev/null 2>&1 || fail "Docker Engine did not create the docker group"
 
 login_user="$(id -un)"

--- a/home/.chezmoiscripts/run_onchange_after_17-install-aws-cli.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_after_17-install-aws-cli.sh.tmpl
@@ -3,10 +3,7 @@
 
 set -euo pipefail
 
-fail() {
-  printf 'error: %s\n' "$*" >&2
-  exit 1
-}
+{{ template "shell-foundation.sh" . }}
 
 expected_version={{ (index .packages.ubuntu.external_tools 0).version | quote }}
 archive_url={{ (index .packages.ubuntu.external_tools 0).url | quote }}

--- a/home/.chezmoiscripts/run_onchange_before_10-install-ubuntu-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_10-install-ubuntu-packages.sh.tmpl
@@ -3,12 +3,8 @@
 
 set -euo pipefail
 
+{{ template "shell-foundation.sh" . }}
 {{ template "ubuntu-package-foundation.sh" . }}
-
-fail() {
-  printf 'error: %s\n' "$*" >&2
-  exit 1
-}
 
 [ -r /etc/os-release ] || fail "cannot identify the operating system"
 # shellcheck disable=SC1091

--- a/home/.chezmoiscripts/run_onchange_before_12-install-ubuntu-deb-artifacts.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_12-install-ubuntu-deb-artifacts.sh.tmpl
@@ -3,10 +3,7 @@
 
 set -euo pipefail
 
-fail() {
-  printf 'error: %s\n' "$*" >&2
-  exit 1
-}
+{{ template "shell-foundation.sh" . }}
 
 [ -r /etc/os-release ] || fail "cannot identify the operating system"
 # shellcheck disable=SC1091

--- a/home/.chezmoitemplates/atomic-json-state.py
+++ b/home/.chezmoitemplates/atomic-json-state.py
@@ -1,0 +1,86 @@
+import glob
+import json
+import os
+import shutil
+import stat
+import sys
+import tempfile
+from datetime import datetime, timezone
+
+
+def read_json_object(
+  path,
+  *,
+  symlink_label,
+  read_context,
+  object_error,
+  default=None,
+  default_mode=0o600,
+):
+  if os.path.lexists(path) and os.path.islink(path):
+    raise SystemExit(f"error: {symlink_label} is a symlink: {path}")
+
+  if not os.path.exists(path):
+    return ({} if default is None else default), default_mode
+
+  try:
+    with open(path, encoding="utf-8") as state_file:
+      state = json.load(state_file)
+  except (OSError, json.JSONDecodeError) as error:
+    raise SystemExit(f"error: cannot read {read_context}: {error}") from error
+
+  if not isinstance(state, dict):
+    raise SystemExit(object_error)
+
+  return state, stat.S_IMODE(os.stat(path).st_mode)
+
+
+def write_json_object(
+  path,
+  state,
+  *,
+  mode,
+  prefix,
+  update_context,
+  indent=None,
+  separators=None,
+  backup_limit=3,
+):
+  directory = os.path.dirname(path)
+  os.makedirs(directory, mode=0o755, exist_ok=True)
+
+  if os.path.exists(path):
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    backup_path = f"{path}.chezmoi-backup.{timestamp}"
+    suffix = 1
+    while os.path.exists(backup_path):
+      backup_path = f"{path}.chezmoi-backup.{timestamp}-{suffix}"
+      suffix += 1
+    shutil.copyfile(path, backup_path)
+    os.chmod(backup_path, mode)
+
+  temporary_path = None
+  try:
+    descriptor, temporary_path = tempfile.mkstemp(prefix=prefix, dir=directory)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as state_file:
+      json.dump(state, state_file, indent=indent, separators=separators, ensure_ascii=False)
+      state_file.write("\n")
+      state_file.flush()
+      os.fsync(state_file.fileno())
+    os.chmod(temporary_path, mode)
+    os.replace(temporary_path, path)
+  except OSError as error:
+    if temporary_path is not None:
+      try:
+        os.unlink(temporary_path)
+      except FileNotFoundError:
+        pass
+    raise SystemExit(f"error: cannot update {update_context}: {error}") from error
+
+  backups = sorted(
+    glob.glob(f"{path}.chezmoi-backup.*"),
+    key=os.path.getmtime,
+    reverse=True,
+  )
+  for old_backup in backups[backup_limit:]:
+    os.unlink(old_backup)

--- a/home/.chezmoitemplates/gnome-settings-foundation.sh
+++ b/home/.chezmoitemplates/gnome-settings-foundation.sh
@@ -1,0 +1,17 @@
+require_gnome_session() {
+  case ":${XDG_CURRENT_DESKTOP:-}${DESKTOP_SESSION:-}": in
+    *[Gg][Nn][Oo][Mm][Ee]*) ;;
+    *) exit 0 ;;
+  esac
+}
+
+set_gsetting_if_changed() {
+  local schema="$1"
+  local key="$2"
+  local value="$3"
+  local expected="$4"
+
+  if [[ "$(gsettings get "${schema}" "${key}")" != "${expected}" ]]; then
+    gsettings set "${schema}" "${key}" "${value}"
+  fi
+}

--- a/home/.chezmoitemplates/shell-foundation.sh
+++ b/home/.chezmoitemplates/shell-foundation.sh
@@ -1,0 +1,21 @@
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_command() {
+  local command_name="$1"
+  local message="${2:-${command_name} is unavailable}"
+
+  command -v "${command_name}" >/dev/null 2>&1 || fail "${message}"
+}
+
+skip_without_command() {
+  local command_name="$1"
+  local message="$2"
+
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    printf 'warning: %s\n' "${message}" >&2
+    exit 0
+  fi
+}

--- a/tests/test-configure-dash-to-dock.sh
+++ b/tests/test-configure-dash-to-dock.sh
@@ -2,14 +2,10 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-script>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_setup 1 "$@"
 script="$1"
-test_root="$(mktemp -d)"
-trap 'rm -rf "$test_root"' EXIT
 export test_root
 
 : > "${test_root}/gsettings.log"
@@ -56,7 +52,7 @@ export -f gsettings
 XDG_CURRENT_DESKTOP=ubuntu:GNOME \
   DESKTOP_SESSION=ubuntu \
   PATH="/usr/bin:/bin:${PATH}" \
-  bash "${script}"
+  test_run_script "${script}"
 
 icon_size="$(cat "${test_root}/icon-size")"
 extend_height="$(cat "${test_root}/extend-height")"
@@ -69,7 +65,7 @@ grep -Fq 'set org.gnome.shell.extensions.dash-to-dock extend-height false' "${te
 XDG_CURRENT_DESKTOP=ubuntu:GNOME \
   DESKTOP_SESSION=ubuntu \
   PATH="/usr/bin:/bin:${PATH}" \
-  bash "${script}"
+  test_run_script "${script}"
 [[ ! -s "${test_root}/gsettings.log" ]]
 
 printf 'Dash to Dock configuration checks passed\n'

--- a/tests/test-configure-docker.sh
+++ b/tests/test-configure-docker.sh
@@ -2,14 +2,10 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-script>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_setup 1 "$@"
 script="$1"
-test_root="$(mktemp -d)"
-trap 'rm -rf "$test_root"' EXIT
 
 id() {
   case "$1" in

--- a/tests/test-configure-flameshot.sh
+++ b/tests/test-configure-flameshot.sh
@@ -2,14 +2,10 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-script>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_setup 1 "$@"
 script="$1"
-test_root="$(mktemp -d)"
-trap 'rm -rf "$test_root"' EXIT
 
 managed_path='/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/flameshot/'
 state_dir="$test_root/state"

--- a/tests/test-configure-gnome-favorites.sh
+++ b/tests/test-configure-gnome-favorites.sh
@@ -2,14 +2,10 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-script>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_setup 1 "$@"
 script="$1"
-test_root="$(mktemp -d)"
-trap 'rm -rf "${test_root}"' EXIT
 export test_root
 
 printf '%s\n' "['firefox_firefox.desktop', 'existing.desktop', 'google-chrome.desktop']" > "${test_root}/favorites"
@@ -48,7 +44,7 @@ export -f gsettings
 XDG_CURRENT_DESKTOP=ubuntu:GNOME \
   DESKTOP_SESSION=ubuntu \
   PATH="/usr/bin:/bin:${PATH}" \
-  bash "${script}"
+  test_run_script "${script}"
 
 favorites="$(cat "${test_root}/favorites")"
 expected="['existing.desktop', 'google-chrome.desktop', 'dbeaver-ce.desktop', 'slack.desktop', 'slayzone.desktop', 'devtoys.desktop', 'obsidian.desktop', 'drawio.desktop']"
@@ -59,7 +55,7 @@ grep -Fq 'set org.gnome.shell favorite-apps' "${test_root}/gsettings.log"
 XDG_CURRENT_DESKTOP=ubuntu:GNOME \
   DESKTOP_SESSION=ubuntu \
   PATH="/usr/bin:/bin:${PATH}" \
-  bash "${script}"
+  test_run_script "${script}"
 [[ ! -s "${test_root}/gsettings.log" ]]
 
 printf 'GNOME favorites configuration checks passed\n'

--- a/tests/test-configure-live-lock-screen.sh
+++ b/tests/test-configure-live-lock-screen.sh
@@ -2,14 +2,10 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-live-lock-screen-config-script>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_setup 1 "$@"
 script="$1"
-test_root="$(mktemp -d)"
-trap 'rm -rf "${test_root}"' EXIT
 export test_root
 
 mkdir -p "${test_root}/bin" "${test_root}/home/.local/share/gnome-shell/extensions/live-lockscreen@nick-redwill/schemas"

--- a/tests/test-configure-ptyxis-font.sh
+++ b/tests/test-configure-ptyxis-font.sh
@@ -2,14 +2,10 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-ptyxis-font-script>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_setup 1 "$@"
 script="$1"
-test_root="$(mktemp -d)"
-trap 'rm -rf "${test_root}"' EXIT
 export test_root
 
 mkdir -p "${test_root}/bin"

--- a/tests/test-configure-repository-workspace.sh
+++ b/tests/test-configure-repository-workspace.sh
@@ -2,11 +2,9 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-workspace-script>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_require_args 1 "$@"
 workspace_script="$1"
 test_home="$(mktemp -d)"
 fake_bin="$test_home/bin"

--- a/tests/test-configure-vitals.sh
+++ b/tests/test-configure-vitals.sh
@@ -2,14 +2,10 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-vitals-config-script>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_setup 1 "$@"
 script="$1"
-test_root="$(mktemp -d)"
-trap 'rm -rf "${test_root}"' EXIT
 export test_root
 
 mkdir -p "${test_root}/home/.local/share/gnome-shell/extensions/Vitals@CoreCoding.com/schemas"
@@ -64,7 +60,7 @@ XDG_CURRENT_DESKTOP=ubuntu:GNOME \
   DESKTOP_SESSION=ubuntu \
   DBUS_SESSION_BUS_ADDRESS=mock \
   HOME="${test_root}/home" \
-  bash "${script}"
+  test_run_script "${script}"
 
 grep -Fq "set org.gnome.shell.extensions.vitals hot-sensors ['_memory_usage_', '_system_load_1m_', '__network-rx_max__']" "${test_root}/changes"
 grep -Fq 'set org.gnome.shell.extensions.vitals position-in-panel 2' "${test_root}/changes"
@@ -74,7 +70,7 @@ XDG_CURRENT_DESKTOP=ubuntu:GNOME \
   DESKTOP_SESSION=ubuntu \
   DBUS_SESSION_BUS_ADDRESS=mock \
   HOME="${test_root}/home" \
-  bash "${script}"
+  test_run_script "${script}"
 [[ ! -s "${test_root}/changes" ]]
 
 printf 'Vitals configuration checks passed\n'

--- a/tests/test-developer-path.sh
+++ b/tests/test-developer-path.sh
@@ -2,11 +2,9 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-zshrc>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_require_args 1 "$@"
 zshrc="$1"
 test_home="$(mktemp -d)"
 trap 'rm -rf "$test_home"' EXIT

--- a/tests/test-dracula-config.sh
+++ b/tests/test-dracula-config.sh
@@ -2,11 +2,9 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-dracula-installer>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_require_args 1 "$@"
 installer="$1"
 grep -Fq 'https://github.com/dracula/gtk.git' "$installer"
 grep -Fq 'https://github.com/dracula/tmux.git' "$installer"

--- a/tests/test-ensure-sudo-group.sh
+++ b/tests/test-ensure-sudo-group.sh
@@ -2,14 +2,10 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-script>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_setup 1 "$@"
 script="$1"
-test_root="$(mktemp -d)"
-trap 'rm -rf "$test_root"' EXIT
 
 id() {
   [[ "$*" == "-un" ]] && printf 'test-user\n'

--- a/tests/test-flameshot-config.sh
+++ b/tests/test-flameshot-config.sh
@@ -2,11 +2,9 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-config>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_require_args 1 "$@"
 config="$1"
 grep -Fxq '[General]' "$config"
 grep -Eq '^savePath=.*/Pictures/Screenshots$' "$config"

--- a/tests/test-flameshot-wayland-gui.sh
+++ b/tests/test-flameshot-wayland-gui.sh
@@ -2,14 +2,10 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <wrapper>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_setup 1 "$@"
 wrapper="$1"
-test_root="$(mktemp -d)"
-trap 'rm -rf "$test_root"' EXIT
 
 mkdir -p "$test_root/bin"
 cat > "$test_root/bin/flameshot" <<'EOF'

--- a/tests/test-google-chrome-theme.sh
+++ b/tests/test-google-chrome-theme.sh
@@ -2,9 +2,10 @@
 
 set -euo pipefail
 
-script_path="${1:?usage: $0 RENDERED_SCRIPT}"
-test_root="$(mktemp -d)"
-trap 'rm -rf "${test_root}"' EXIT
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_setup 1 "$@"
+script_path="$1"
 
 mkdir -p \
   "${test_root}/bin" \
@@ -24,6 +25,12 @@ cat >"${test_root}/bin/sudo" <<'EOF'
 exec "$@"
 EOF
 chmod +x "${test_root}/bin/sudo"
+
+cat >"${test_root}/bin/ps" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "${test_root}/bin/ps"
 
 cat >"${test_root}/chrome/Default/Preferences" <<'EOF'
 {"profile":{"name":"Default"},"extensions":{"theme":{"system_theme":1}},"unrelated":{"keep":true}}

--- a/tests/test-helpers.sh
+++ b/tests/test-helpers.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+test_require_args() {
+  local expected_args="$1"
+  shift
+
+  [[ $# -eq "${expected_args}" ]] || {
+    printf 'usage: %s expects %s argument(s)\n' "$0" "${expected_args}" >&2
+    exit 2
+  }
+}
+
+test_setup() {
+  test_require_args "$@"
+  test_root="$(mktemp -d)"
+  trap 'rm -rf "${test_root}"' EXIT
+}
+
+test_run_script() {
+  local script="$1"
+  shift
+
+  bash "${script}" "$@"
+}
+
+test_assert_file_contains() {
+  local expected="$1"
+  local file="$2"
+
+  grep -Fq -- "${expected}" "${file}"
+}

--- a/tests/test-install-aws-cli.sh
+++ b/tests/test-install-aws-cli.sh
@@ -2,11 +2,9 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-installer>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_require_args 1 "$@"
 installer="$1"
 grep -Fq 'awscli-exe-linux-x86_64.zip' "$installer"
 grep -Fq 'awscli-exe-linux-x86_64.zip.sig' "$installer"

--- a/tests/test-install-dotnet-templates.sh
+++ b/tests/test-install-dotnet-templates.sh
@@ -2,14 +2,10 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-dotnet-templates-script>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_setup 1 "$@"
 script="$1"
-test_root="$(mktemp -d)"
-trap 'rm -rf "${test_root}"' EXIT
 
 mkdir -p "${test_root}/bin" "${test_root}/home" "${test_root}/empty"
 : > "${test_root}/template-actions"

--- a/tests/test-install-dotnet-tools.sh
+++ b/tests/test-install-dotnet-tools.sh
@@ -2,14 +2,10 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-dotnet-tools-script>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_setup 1 "$@"
 script="$1"
-test_root="$(mktemp -d)"
-trap 'rm -rf "${test_root}"' EXIT
 
 mkdir -p "${test_root}/bin" "${test_root}/home" "${test_root}/empty"
 : > "${test_root}/tool-actions"

--- a/tests/test-install-gnome-shell-extensions.sh
+++ b/tests/test-install-gnome-shell-extensions.sh
@@ -2,14 +2,10 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-script>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_setup 1 "$@"
 script="$1"
-test_root="$(mktemp -d)"
-trap 'rm -rf "$test_root"' EXIT
 
 mkdir -p "$test_root/bin" "$test_root/home/.local/share/gnome-shell/extensions"
 mkdir -p "$test_root/home/.local/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com"

--- a/tests/test-install-ubuntu-deb-artifacts.sh
+++ b/tests/test-install-ubuntu-deb-artifacts.sh
@@ -2,11 +2,9 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-installer>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_require_args 1 "$@"
 installer="$1"
 grep -Fq 'k9s_linux_amd64.deb' "$installer"
 grep -Fq '56b539a509eb2d6357cf4f575ed38c089f0e4880c95f79a70196b54f14954908' "$installer"

--- a/tests/test-install-ubuntu-packages.sh
+++ b/tests/test-install-ubuntu-packages.sh
@@ -2,14 +2,10 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-installer>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_setup 1 "$@"
 installer="$1"
-test_root="$(mktemp -d)"
-trap 'rm -rf "$test_root"' EXIT
 
 grep -Fq '"flameshot"' "$installer"
 grep -Fq '"qt6-wayland"' "$installer"

--- a/tests/test-install-vscode-extensions.sh
+++ b/tests/test-install-vscode-extensions.sh
@@ -2,11 +2,9 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-installer>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_require_args 1 "$@"
 installer="$1"
 grep -Fq 'hediet.vscode-drawio' "$installer"
 grep -Fq 'dracula-theme.theme-dracula' "$installer"

--- a/tests/test-kubernetes-shell.sh
+++ b/tests/test-kubernetes-shell.sh
@@ -2,17 +2,15 @@
 
 set -euo pipefail
 
-[[ $# -eq 2 ]] || {
-  printf 'usage: %s <rendered-zshrc> <p10k-config>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_require_args 2 "$@"
 zshrc="$1"
 p10k="$2"
 
-grep -Fq "alias k='kubectl'" "$zshrc"
-grep -Fq 'kubectl completion zsh' "$zshrc"
-grep -Fq 'compdef _kubectl k' "$zshrc"
+test_assert_file_contains "alias k='kubectl'" "$zshrc"
+test_assert_file_contains 'kubectl completion zsh' "$zshrc"
+test_assert_file_contains 'compdef _kubectl k' "$zshrc"
 grep -Fq 'helm completion zsh' "$zshrc"
 grep -Fq "alias kx='kubectx'" "$zshrc"
 grep -Fq "alias kn='kubens'" "$zshrc"

--- a/tests/test-mise-config.sh
+++ b/tests/test-mise-config.sh
@@ -2,11 +2,9 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <mise-config>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_require_args 1 "$@"
 config="$1"
 grep -Fq 'version = "lts"' "$config"
 grep -Fq 'corepack = true' "$config"

--- a/tests/test-p10k-colors.sh
+++ b/tests/test-p10k-colors.sh
@@ -2,11 +2,9 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-p10k-config>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_require_args 1 "$@"
 p10k="$1"
 
 grep -Fqx 'typeset -g POWERLEVEL9K_BACKGROUND=' "${p10k}"

--- a/tests/test-slack-obsidian-themes.sh
+++ b/tests/test-slack-obsidian-themes.sh
@@ -2,15 +2,11 @@
 
 set -euo pipefail
 
-[[ $# -eq 2 ]] || {
-  printf 'usage: %s <rendered-slack-script> <rendered-obsidian-script>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_setup 2 "$@"
 slack_script="$1"
 obsidian_script="$2"
-test_root="$(mktemp -d)"
-trap 'rm -rf "${test_root}"' EXIT
 
 mkdir -p \
   "${test_root}/bin" \
@@ -23,6 +19,12 @@ printf 'unexpected git clone\n' >&2
 exit 1
 EOF
 chmod +x "${test_root}/bin/git"
+
+cat >"${test_root}/bin/ps" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "${test_root}/bin/ps"
 
 cat >"${test_root}/slack/storage/root-state.json" <<'EOF'
 {"settings":{"userTheme":"light","systemThemeSyncEnabled":true},"webapp":{"teams":{"T123":{"theme":{"titlebarBackground":"#350d36","titlebarTextColor":"#FFFFFF"}}}}}

--- a/tests/test-tmux-config.sh
+++ b/tests/test-tmux-config.sh
@@ -2,11 +2,9 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <tmux-config>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_require_args 1 "$@"
 config="$1"
 grep -Fq 'set -g mouse on' "$config"
 grep -Fq 'set -g focus-events on' "$config"

--- a/tests/test-ubuntu-package-foundation.sh
+++ b/tests/test-ubuntu-package-foundation.sh
@@ -2,15 +2,11 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-foundation>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_setup 1 "$@"
 foundation_source="$1"
-test_root="$(mktemp -d)"
-curl_log="$test_root/curl.log"
-trap 'rm -rf "$test_root"' EXIT
+curl_log="${test_root}/curl.log"
 
 source "$foundation_source"
 

--- a/tests/test-update-matt-pocock-skills.sh
+++ b/tests/test-update-matt-pocock-skills.sh
@@ -2,11 +2,9 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-updater>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_require_args 1 "$@"
 updater="$1"
 test_home="$(mktemp -d)"
 trap 'rm -rf "$test_home"' EXIT

--- a/tests/test-verify-1password-setup.sh
+++ b/tests/test-verify-1password-setup.sh
@@ -2,11 +2,9 @@
 
 set -euo pipefail
 
-[[ $# -eq 1 ]] || {
-  printf 'usage: %s <rendered-verifier>\n' "$0" >&2
-  exit 2
-}
-
+# shellcheck source=test-helpers.sh
+. "$(dirname "${BASH_SOURCE[0]}")/test-helpers.sh"
+test_require_args 1 "$@"
 verifier_source="$1"
 test_home="$(mktemp -d)"
 socket_pid=""


### PR DESCRIPTION
## Summary

- Extract reusable render-time shell and GNOME settings fragments.
- Centralize atomic JSON state handling across VS Code, Chrome, Slack, and Obsidian.
- Add shared test lifecycle, execution, and assertion helpers and update CI.
- Resolve the DRY refactoring wayfinder tickets and record the architectural decisions.

## Validation

- Rendered scripts with `bash -n` and ShellCheck.
- Ran the focused and rendered validation test matrix.
- Ran `chezmoi apply --dry-run --verbose --no-tty`.
- Ran `chezmoi verify --exclude scripts`.