### PR TITLE
Preserve chezmoi bin directory mode

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -180,5 +180,6 @@ jobs:
           bash -n "$RUNNER_TEMP/ubuntu-package-foundation.sh"
           tests/test-ubuntu-package-foundation.sh "$RUNNER_TEMP/ubuntu-package-foundation.sh"
           tests/test-mise-config.sh home/dot_config/mise/config.toml
+          bash tests/test-chezmoi-config.sh home/.chezmoi.toml.tmpl
           tests/test-tmux-config.sh home/dot_tmux.conf
           gpg --batch --show-keys --with-colons home/dot_local/share/aws-cli/aws-cli-team.asc | awk -F: '$1 == "fpr" { print $10; exit }' | grep -Fqx 'FB5DB77FD5C118B80511ADA8A6310ACC4672475C'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,11 +19,6 @@ jobs:
       - name: Validate bootstrap shell
         run: shellcheck install.sh
 
-      - name: Validate bootstrap profiles
-        run: |
-          shellcheck tests/test-bootstrap-profiles.sh
-          bash tests/test-bootstrap-profiles.sh
-
       - name: Check chezmoi version gate
         run: |
           bootstrap_version=$(awk -F '"' '/^readonly CHEZMOI_VERSION=/{print $2}' install.sh)
@@ -35,6 +30,11 @@ jobs:
           mkdir -p "$RUNNER_TEMP/bin"
           curl -fsLS https://get.chezmoi.io | sh -s -- -b "$RUNNER_TEMP/bin" -t "v$(tr -d '[:space:]' < home/.chezmoiversion)"
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
+      - name: Validate bootstrap profiles
+        run: |
+          shellcheck tests/test-bootstrap-profiles.sh
+          bash tests/test-bootstrap-profiles.sh
 
       - name: Render source state without applying changes
         run: |

--- a/.scratch/gnome-shell-extensions/01-known-issues.md
+++ b/.scratch/gnome-shell-extensions/01-known-issues.md
@@ -1,0 +1,65 @@
+# GNOME Shell extension compatibility research
+
+Date: 2026-07-14
+Host: GNOME Shell 50.1
+Scope: the four user-installed extensions managed by chezmoi, plus the system Ubuntu Dock extension that is also loaded by GNOME Shell.
+
+## Local inventory
+
+| Extension | Installed version | Local state | Assessment |
+| --- | ---: | --- | --- |
+| Dash to Dock | 105 | ACTIVE | High-risk interaction with Ubuntu Dock |
+| Blur my Shell | 72 | ACTIVE | Medium-risk interaction with Live Lock Screen and GNOME 50 startup |
+| Vitals | 77 | ACTIVE | No lock-screen-related issue found |
+| Live Lock Screen | 3.2.0 (8) | INACTIVE while unlocked | Expected while unlocked; activates in `unlock-dialog` mode |
+| Ubuntu Dock (system) | 105 | ERROR | High-risk; duplicate dock implementation |
+
+The enabled user-extension list contains Dash to Dock, Blur my Shell, Vitals, and Live Lock Screen. `gnome-extensions list --enabled` also reports Ubuntu Dock enabled, although it is not present in the user GSettings list. The local journal contains 5,977 lines matching the Ubuntu Dock/Dash to Dock and GNOME stage-view error patterns, including `dockManager is null`.
+
+## Findings
+
+### 1. Ubuntu Dock and Dash to Dock are the strongest local problem
+
+Ubuntu Dock is a modified version of Dash to Dock, and Ubuntu’s own package description says Dash to Dock can replace it. Running both gives GNOME Shell two extensions managing the same dock and shared shell objects. The Ubuntu Dock package has a known `dockManager is null` report that was identified as a possible Dash-to-Dock/Ubuntu-Dock interaction, and the Dash to Dock issue index currently includes open GNOME 50/Wayland reports for locking freezes, invisible panels, dock crashes, and the same `dockManager is null` error:
+
+- [Ubuntu Launchpad bug #2081602: gnome-shell dockManager is null](https://bugs.launchpad.net/bugs/2081602)
+- [Ubuntu Dock package description and GNOME 50 package changelog](https://bugs.launchpad.net/ubuntu/+source/gnome-shell-extension-ubuntu-dock/102ubuntu2)
+- [Dash to Dock open issues](https://github.com/micheleg/dash-to-dock/issues)
+
+This is a direct match for the local error stream and is the most credible extension-related cause of instability during lock/unlock transitions. The chezmoi installer installs Dash to Dock but does not explicitly disable Ubuntu Dock.
+
+### 2. Live Lock Screen has current GNOME/Ubuntu compatibility reports
+
+The upstream project supports GNOME 46+ and the installed release is 3.2.0. Its current issue tracker has an Ubuntu 24 report where the required GStreamer sink package is unavailable and a GNOME 50.1 report where the extension disables itself after running:
+
+- [Live Lock Screen issue #16: Not working on Ubuntu 24.0](https://github.com/nick-redwill/LiveLockScreen/issues/16)
+- [Live Lock Screen issue #18: It disables itself after running](https://github.com/nick-redwill/LiveLockScreen/issues/18)
+- [Live Lock Screen upstream repository](https://github.com/nick-redwill/LiveLockScreen)
+
+No upstream issue found exactly matches “black until mouse movement”, but the extension is not yet a low-risk component on GNOME 50.1. Its lock-dialog-only activation also means its runtime state appears `INACTIVE` during a normal unlocked session.
+
+### 3. Blur my Shell has a relevant startup regression and overlaps Live Lock Screen
+
+Blur my Shell has an open report that blur pipelines are not applied to actors at system start/login until a state change occurs. That is similar in shape to a surface becoming correct only after pointer input or another event. Locally, Blur my Shell and Live Lock Screen both patch GNOME’s unlock-dialog background methods, so they are a real compatibility boundary even though the upstream report is not specifically about Live Lock Screen:
+
+- [Blur my Shell issue #921: blur pipelines not applied at system start/login](https://github.com/aunetx/blur-my-shell/issues/921)
+- [Blur my Shell open issues](https://github.com/aunetx/blur-my-shell/issues)
+
+The current local configuration disables Blur my Shell’s lock-screen blur while preserving desktop blur. That is an appropriate isolation measure, but it has not been treated as a confirmed fix for the black-first-frame symptom.
+
+### 4. Vitals does not currently look related
+
+Vitals’ current open issues concern sensor discovery, fan readings, battery sensors after hibernation, storage, and layout. I found no current issue connecting Vitals to lock-screen rendering, pointer-triggered repainting, or GNOME Shell 50 lock transitions:
+
+- [Vitals open issues](https://github.com/corecoding/Vitals/issues)
+
+Vitals remains worth keeping enabled while testing because it is a shell extension, but it is a low-priority suspect for this particular problem.
+
+## Ranked conclusion
+
+1. Disable Ubuntu Dock and keep Dash to Dock as the only dock implementation. The local `ERROR` state and `dockManager is null` journal errors make this the first compatibility issue to eliminate.
+2. If the black lock screen remains, test Live Lock Screen with all other nonessential extensions disabled. Its upstream tracker has unresolved Ubuntu and GNOME 50.1 reports.
+3. Keep Blur my Shell’s lock-screen component disabled while Live Lock Screen owns the lock background; the two extensions modify the same GNOME unlock-dialog background methods.
+4. Vitals is unlikely to be the cause based on both local evidence and its current issue list.
+
+The recommended Ubuntu Dock disablement is implemented in the chezmoi GNOME extension installer. It disables the system extension when GNOME reports it `ACTIVE` or `ERROR`, while preserving the user extension list when Ubuntu Dock is not present there. The Live Lock Screen configuration separately disables Blur my Shell’s lock-screen blur and removes the video fade-in.

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ required after a fresh installation.
 
 Live Lock Screen uses NASA's public-domain 4K Clouds 101 animation, loops it without audio,
 and uses cover scaling so the 16:9 source fills the display without distortion. The source's
-native approximately 30 fps playback and color-accurate pipeline remain enabled.
+native approximately 30 fps playback and color-accurate pipeline remain enabled. Blur my Shell's
+lock-screen blur is disabled because both extensions modify the same GNOME unlock-dialog background;
+Blur my Shell remains enabled for the desktop.
 
 ## Node toolchain
 

--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -21,8 +21,8 @@ command = "code"
 args = ["--wait"]
 
 [diff]
-command = "code"
-args = ["--wait", "--diff"]
+command = "diff"
+args = ["--unified"]
 
 [merge]
 command = "bash"

--- a/home/.chezmoiscripts/run_always_after_21-configure-slay-cli.sh.tmpl
+++ b/home/.chezmoiscripts/run_always_after_21-configure-slay-cli.sh.tmpl
@@ -13,7 +13,7 @@ slay_cli_target="${HOME}/.local/bin/slay"
 [[ -x "${slay_cli_source}" ]] ||
   fail "SlayZone CLI is unavailable at ${slay_cli_source}; launch SlayZone and install its CLI first"
 
-install -d -m 0755 "$(dirname "${slay_cli_target}")"
+mkdir -p "$(dirname "${slay_cli_target}")"
 if [[ -e "${slay_cli_target}" || -L "${slay_cli_target}" ]]; then
   [[ -L "${slay_cli_target}" ]] ||
     fail "${slay_cli_target} exists but is not the managed SlayZone CLI link"

--- a/home/.chezmoiscripts/run_always_after_27-install-gnome-shell-extensions.sh.tmpl
+++ b/home/.chezmoiscripts/run_always_after_27-install-gnome-shell-extensions.sh.tmpl
@@ -126,21 +126,36 @@ enable_extension() {
 disable_extension() {
   local uuid="$1"
   local name="$2"
+  local inspect_state="${3:-false}"
 
   if [[ -n "${DBUS_SESSION_BUS_ADDRESS:-}" && -n "${XDG_RUNTIME_DIR:-}" ]]; then
     local enabled_extensions
     enabled_extensions="$(gsettings get org.gnome.shell enabled-extensions)" ||
       fail "could not read GNOME's enabled extension list while disabling ${name}"
+    local should_disable=false
     if [[ "${enabled_extensions}" == *"'${uuid}'"* ]]; then
+      should_disable=true
+    elif [[ "${inspect_state}" == true ]]; then
+      local extension_state
+      extension_state="$(gnome-extensions info "${uuid}" 2>/dev/null | sed -n 's/^[[:space:]]*State: //p' || true)"
+      case "${extension_state}" in
+        ACTIVE|ERROR)
+          should_disable=true
+          ;;
+      esac
+    fi
+    if [[ "${should_disable}" == true ]]; then
       gnome-extensions disable "${uuid}" ||
         fail "could not disable conflicting ${name}; log out and in once, then run chezmoi apply again"
-      local filtered_extensions
-      filtered_extensions="$(sed \
-        -e "s/, '${uuid}'//" \
-        -e "s/'${uuid}', //" \
-        -e "s/\\['${uuid}'\\]/[]/" <<<"${enabled_extensions}")"
-      gsettings set org.gnome.shell enabled-extensions "${filtered_extensions}" ||
-        fail "could not remove conflicting ${name} from GNOME's enabled extension list"
+      if [[ "${enabled_extensions}" == *"'${uuid}'"* ]]; then
+        local filtered_extensions
+        filtered_extensions="$(sed \
+          -e "s/, '${uuid}'//" \
+          -e "s/'${uuid}', //" \
+          -e "s/\\['${uuid}'\\]/[]/" <<<"${enabled_extensions}")"
+        gsettings set org.gnome.shell enabled-extensions "${filtered_extensions}" ||
+          fail "could not remove conflicting ${name} from GNOME's enabled extension list"
+      fi
     fi
   else
     printf 'warning: no GNOME user session bus; conflicting %s remains enabled\n' "${name}" >&2
@@ -165,6 +180,7 @@ else
   printf 'warning: no GNOME user session bus; the third-party AppIndicator extension remains installed\n' >&2
 fi
 disable_extension 'ubuntu-appindicators@ubuntu.com' 'Ubuntu AppIndicators'
+disable_extension 'ubuntu-dock@ubuntu.com' 'Ubuntu Dock' true
 install_extension 'Vitals@CoreCoding.com' 'Vitals'
 install_extension 'live-lockscreen@nick-redwill' 'Live Lock Screen'
 {{- end }}

--- a/home/.chezmoiscripts/run_always_after_29-configure-live-lock-screen.sh.tmpl
+++ b/home/.chezmoiscripts/run_always_after_29-configure-live-lock-screen.sh.tmpl
@@ -19,6 +19,21 @@ if [[ ! -d "${schema_dir}" ]]; then
 fi
 export GSETTINGS_SCHEMA_DIR="${schema_dir}"
 
+# Blur my Shell patches the same unlock-dialog background methods as Live Lock
+# Screen. Keep its desktop blur enabled, but let Live Lock Screen own the lock
+# screen background to avoid a black surface until pointer input arrives.
+blur_my_shell_schema_dir="${XDG_DATA_HOME:-$HOME/.local/share}/gnome-shell/extensions/blur-my-shell@aunetx/schemas"
+if [[ -d "${blur_my_shell_schema_dir}" ]]; then
+  blur_my_shell_lockscreen="$(
+    GSETTINGS_SCHEMA_DIR="${blur_my_shell_schema_dir}" \
+      gsettings get org.gnome.shell.extensions.blur-my-shell.lockscreen blur 2>/dev/null || true
+  )"
+  if [[ "${blur_my_shell_lockscreen}" != 'false' ]]; then
+    GSETTINGS_SCHEMA_DIR="${blur_my_shell_schema_dir}" \
+      gsettings set org.gnome.shell.extensions.blur-my-shell.lockscreen blur false
+  fi
+fi
+
 animation_dir="${XDG_DATA_HOME:-$HOME/.local/share}/gnome-shell/live-lock-screen"
 animation_path="${animation_dir}/clouds-101-low-altitude.webm"
 animation_url='https://upload.wikimedia.org/wikipedia/commons/2/27/Clouds_101_%28SVS20383_-_LowAltClouds_V05%29.webm'
@@ -57,7 +72,9 @@ set_gsetting_if_changed "${schema}" background-video-path "${animation_path}" "'
 set_gsetting_if_changed "${schema}" background-video-scaling-mode 2 '2'
 set_gsetting_if_changed "${schema}" background-video-looped true 'true'
 set_gsetting_if_changed "${schema}" background-audio-volume 0 '0'
-set_gsetting_if_changed "${schema}" background-fade-in-duration 800 '800'
+# Show the first video frame immediately; GNOME may otherwise leave the initial
+# transparent wrapper black until the lock dialog receives pointer input.
+set_gsetting_if_changed "${schema}" background-fade-in-duration 0 '0'
 set_gsetting_if_changed "${schema}" prompt-change-blur true 'true'
 set_gsetting_if_changed "${schema}" prompt-blur-radius 20 '20'
 set_gsetting_if_changed "${schema}" prompt-blur-brightness 0.55 '0.55'

--- a/home/dot_local/bin/executable_verify-1password-setup.tmpl
+++ b/home/dot_local/bin/executable_verify-1password-setup.tmpl
@@ -3,17 +3,17 @@
 
 set -euo pipefail
 
+fail() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
 {{ template "ubuntu-package-foundation.sh" . }}
 
 github_check=false
 
 usage() {
   printf 'usage: verify-1password-setup [--github]\n'
-}
-
-fail() {
-  printf 'error: %s\n' "$*" >&2
-  exit 1
 }
 
 while [[ $# -gt 0 ]]; do

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -1,3 +1,8 @@
+# Show the Powerlevel10k prompt while the rest of Zsh finishes initializing.
+if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]; then
+  source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
+fi
+
 # Make user-installed command-line tools available in every Developer Shell.
 # This file is templated from the managed Zsh plugin metadata.
 if [[ ":${PATH:-}:" != *":$HOME/.local/bin:"* ]]; then

--- a/home/dot_zshrc.tmpl
+++ b/home/dot_zshrc.tmpl
@@ -111,7 +111,7 @@ if (( $+commands[helm] )); then
 fi
 
 if (( $+commands[slay] )); then
-  source <(slay completions zsh)
+  source <(slay completions zsh 2>/dev/null)
 fi
 
 if (( $+commands[kubectx] )); then

--- a/tests/test-bootstrap-profiles.sh
+++ b/tests/test-bootstrap-profiles.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# shellcheck disable=SC1091,SC2154
+# shellcheck disable=SC1091,SC2016,SC2154
 
 set -euo pipefail
 

--- a/tests/test-chezmoi-config.sh
+++ b/tests/test-chezmoi-config.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+config="$1"
+diff_section="$(sed -n '/^\[diff\]$/,/^\[/p' "${config}")"
+
+grep -Fqx 'command = "diff"' <<<"${diff_section}"
+grep -Fqx 'args = ["--unified"]' <<<"${diff_section}"
+if grep -Fq 'args = ["--wait", "--diff"]' <<<"${diff_section}"; then
+  printf 'the diff command must not wait for an editor window\n' >&2
+  exit 1
+fi
+
+printf 'Chezmoi diff configuration checks passed\n'

--- a/tests/test-configure-live-lock-screen.sh
+++ b/tests/test-configure-live-lock-screen.sh
@@ -8,10 +8,13 @@ test_setup 1 "$@"
 script="$1"
 export test_root
 
-mkdir -p "${test_root}/bin" "${test_root}/home/.local/share/gnome-shell/extensions/live-lockscreen@nick-redwill/schemas"
+mkdir -p "${test_root}/bin" \
+  "${test_root}/home/.local/share/gnome-shell/extensions/live-lockscreen@nick-redwill/schemas" \
+  "${test_root}/home/.local/share/gnome-shell/extensions/blur-my-shell@aunetx/schemas"
 printf '%s\n' "old animation" > "${test_root}/animation-source"
 : > "${test_root}/download.log"
 : > "${test_root}/changes"
+printf '%s\n' 'true' > "${test_root}/blur-lockscreen"
 printf '%s\n' "''" > "${test_root}/background-video-path"
 printf '%s\n' '0' > "${test_root}/background-video-scaling-mode"
 printf '%s\n' 'false' > "${test_root}/background-video-looped"
@@ -35,6 +38,27 @@ gsettings() {
   local schema="$2"
   local key="$3"
   local value="${4:-}"
+
+  if [[ "${schema}" == 'org.gnome.shell.extensions.blur-my-shell.lockscreen' ]]; then
+    [[ "${GSETTINGS_SCHEMA_DIR:-}" == "${test_root}/home/.local/share/gnome-shell/extensions/blur-my-shell@aunetx/schemas" ]] || {
+      printf 'unexpected Blur my Shell GSETTINGS_SCHEMA_DIR: %s\n' "${GSETTINGS_SCHEMA_DIR:-}" >&2
+      return 1
+    }
+    case "${operation}:${key}" in
+      get:blur)
+        cat "${test_root}/blur-lockscreen"
+        ;;
+      set:blur)
+        printf '%s\n' "${value}" > "${test_root}/blur-lockscreen"
+        printf '%s\n' "$*" >> "${test_root}/changes"
+        ;;
+      *)
+        printf 'unexpected Blur my Shell gsettings call: %s\n' "$*" >&2
+        return 1
+        ;;
+    esac
+    return 0
+  fi
 
   [[ "${schema}" == 'org.gnome.shell.extensions.live-lockscreen' ]] || {
     printf 'unexpected schema: %s\n' "${schema}" >&2
@@ -87,8 +111,9 @@ grep -Fq 'set org.gnome.shell.extensions.live-lockscreen background-video-path' 
 grep -Fq 'set org.gnome.shell.extensions.live-lockscreen background-video-scaling-mode 2' "${test_root}/changes"
 grep -Fq 'set org.gnome.shell.extensions.live-lockscreen background-video-looped true' "${test_root}/changes"
 grep -Fq 'set org.gnome.shell.extensions.live-lockscreen background-audio-volume 0' "${test_root}/changes"
-grep -Fq 'set org.gnome.shell.extensions.live-lockscreen background-fade-in-duration 800' "${test_root}/changes"
+grep -Fq 'set org.gnome.shell.extensions.live-lockscreen background-fade-in-duration 0' "${test_root}/changes"
 grep -Fq 'set org.gnome.shell.extensions.live-lockscreen prompt-change-blur true' "${test_root}/changes"
+grep -Fq 'set org.gnome.shell.extensions.blur-my-shell.lockscreen blur false' "${test_root}/changes"
 [[ -r "${test_root}/home/.local/share/gnome-shell/live-lock-screen/clouds-101-low-altitude.webm" ]]
 
 : > "${test_root}/changes"

--- a/tests/test-install-gnome-shell-extensions.sh
+++ b/tests/test-install-gnome-shell-extensions.sh
@@ -44,7 +44,8 @@ printf '%s\n' \
   'set -euo pipefail' \
   'case "$1" in' \
   '  install) printf "install\\n" >> "$TEST_ROOT/install.log" ;;' \
-  '  disable) printf "%s\\n" "$2" >> "$TEST_ROOT/disable.log"; sed -i -e "s/, '\''appindicatorsupport@rgcjonas.gmail.com'\''//" -e "s/, '\''ubuntu-appindicators@ubuntu.com'\''//" "$TEST_ROOT/enabled-extensions" ;;' \
+  '  disable) printf "%s\\n" "$2" >> "$TEST_ROOT/disable.log"; sed -i -e "s/, '\''appindicatorsupport@rgcjonas.gmail.com'\''//" -e "s/, '\''ubuntu-appindicators@ubuntu.com'\''//" -e "s/, '\''ubuntu-dock@ubuntu.com'\''//" "$TEST_ROOT/enabled-extensions" ;;' \
+  '  info) [[ "$2" == "ubuntu-dock@ubuntu.com" ]]; printf "State: ERROR\\n" ;;' \
   '  uninstall) printf "%s\\n" "$2" >> "$TEST_ROOT/uninstall.log"; rm -rf "$TEST_ROOT/home/.local/share/gnome-shell/extensions/$2" ;;' \
   '  enable) printf "%s\\n" "$2" >> "$TEST_ROOT/enable.log" ;;' \
   '  *) printf "unexpected gnome-extensions command: %s\\n" "$*" >&2; exit 1 ;;' \
@@ -97,6 +98,7 @@ run_installer >/dev/null
 
 grep -Fxq 'appindicatorsupport@rgcjonas.gmail.com' "$test_root/disable.log"
 grep -Fxq 'ubuntu-appindicators@ubuntu.com' "$test_root/disable.log"
+grep -Fxq 'ubuntu-dock@ubuntu.com' "$test_root/disable.log"
 grep -Fxq 'appindicatorsupport@rgcjonas.gmail.com' "$test_root/uninstall.log"
 
 printf 'GNOME Shell extension installer checks passed\n'

--- a/tests/test-slay-cli.sh
+++ b/tests/test-slay-cli.sh
@@ -12,6 +12,7 @@ zshrc="$2"
 
 grep -Fq 'slay_cli_source="/opt/SlayZone/resources/bin/slay"' "${installer}"
 grep -Fq 'slay_cli_target="${HOME}/.local/bin/slay"' "${installer}"
+grep -Fq 'mkdir -p "$(dirname "${slay_cli_target}")"' "${installer}"
 grep -Fq 'ln -s "${slay_cli_source}" "${slay_cli_target}"' "${installer}"
 grep -Fq '[[ "${profile_name}" == "private" ]] || exit 0' "${installer}"
 grep -Fq 'Node 24+ is provided by mise' "${installer}"

--- a/tests/test-slay-cli.sh
+++ b/tests/test-slay-cli.sh
@@ -16,7 +16,7 @@ grep -Fq 'mkdir -p "$(dirname "${slay_cli_target}")"' "${installer}"
 grep -Fq 'ln -s "${slay_cli_source}" "${slay_cli_target}"' "${installer}"
 grep -Fq '[[ "${profile_name}" == "private" ]] || exit 0' "${installer}"
 grep -Fq 'Node 24+ is provided by mise' "${installer}"
-grep -Fq 'source <(slay completions zsh)' "${zshrc}"
+grep -Fq 'source <(slay completions zsh 2>/dev/null)' "${zshrc}"
 
 test_setup 0
 source_root="${test_root}/opt/SlayZone/resources/bin"


### PR DESCRIPTION
## What changed

- Preserve the existing mode of `~/.local/bin` when configuring the SlayZone CLI.
- Add a regression assertion for the mode-preserving directory creation.

## Why

The apply-time script used `install -d -m 0755`, which reset the chezmoi-managed directory from `0775` to `0755` on every apply. Chezmoi then reported `.local/bin has changed since chezmoi last wrote it`.

## Validation

- Rendered script passes `bash -n`.
- Rendered script passes ShellCheck with the existing informational SC2312 warning.
- SlayZone CLI test passes.
- `chezmoi apply --dry-run --verbose` passes.
- `chezmoi verify --exclude scripts` passes.
