### PR TITLE
Configure Vitals sensor order

### DIFF
--- a/home/.chezmoiscripts/run_always_after_28-configure-vitals.sh.tmpl
+++ b/home/.chezmoiscripts/run_always_after_28-configure-vitals.sh.tmpl
@@ -22,7 +22,7 @@ if ! gsettings writable "${schema}" hot-sensors >/dev/null 2>&1 ||
   exit 0
 fi
 
-desired_hot_sensors="['_memory_usage_', '_system_load_1m_', '__network-rx_max__']"
+desired_hot_sensors="['_memory_usage_', '_processor_usage_', '__network-rx_max__', '__temperature_avg__']"
 set_gsetting_if_changed "${schema}" hot-sensors "${desired_hot_sensors}" "${desired_hot_sensors}"
 set_gsetting_if_changed "${schema}" position-in-panel 2 '2'
 {{- end }}

--- a/tests/test-configure-vitals.sh
+++ b/tests/test-configure-vitals.sh
@@ -62,7 +62,7 @@ XDG_CURRENT_DESKTOP=ubuntu:GNOME \
   HOME="${test_root}/home" \
   test_run_script "${script}"
 
-grep -Fq "set org.gnome.shell.extensions.vitals hot-sensors ['_memory_usage_', '_system_load_1m_', '__network-rx_max__']" "${test_root}/changes"
+grep -Fq "set org.gnome.shell.extensions.vitals hot-sensors ['_memory_usage_', '_processor_usage_', '__network-rx_max__', '__temperature_avg__']" "${test_root}/changes"
 grep -Fq 'set org.gnome.shell.extensions.vitals position-in-panel 2' "${test_root}/changes"
 
 : > "${test_root}/changes"


### PR DESCRIPTION
## What changed

Configure GNOME Vitals to show memory usage, processor usage, network usage, and temperature in that order.

## Validation

- Rendered the chezmoi template and ran ShellCheck
- Ran the Vitals configuration regression test
- Ran `chezmoi verify --exclude scripts`
- Ran `git diff --check`