### PR TITLE
Resume an interrupted package install instead of rejecting it

### DIFF
--- a/home/.chezmoiscripts/run_onchange_before_10-install-ubuntu-packages.sh.tmpl
+++ b/home/.chezmoiscripts/run_onchange_before_10-install-ubuntu-packages.sh.tmpl
@@ -37,6 +37,8 @@ if command -v flatpak >/dev/null 2>&1 && flatpak info com.onepassword.OnePasswor
   fail "Flatpak 1Password is installed; remove or migrate it before managing 1Password Stable"
 fi
 
+resume_interrupted_repository_packages
+
 for repository_name in "${repository_names[@]}"; do
   repository_enabled "${repository_name}" || continue
   fail_on_unmanaged_repository "${repository_name}" || exit 1

--- a/home/.chezmoitemplates/ubuntu-package-foundation.sh
+++ b/home/.chezmoitemplates/ubuntu-package-foundation.sh
@@ -138,8 +138,59 @@ repository_enabled() {
   [[ -z "${required_profile}" || "${required_profile}" == "${profile_name}" ]]
 }
 
+# The state dpkg records for a package, as one of its own status words, and
+# not-installed for a package dpkg has never heard of.
+package_status() {
+  local status
+
+  status="$(dpkg-query -W -f='${db:Status-Status}' "$1" 2>/dev/null || true)"
+  printf '%s\n' "${status:-not-installed}"
+}
+
 package_installed() {
-  [[ "$(dpkg-query -W -f='${db:Status-Status}' "$1" 2>/dev/null || true)" == "installed" ]]
+  [[ "$(package_status "$1")" == "installed" ]]
+}
+
+# dpkg leaves a package whose installation it began but could not finish with its
+# files already on disk, so the package's commands resolve while the package
+# itself is not installed. A bootstrap interrupted by a failing maintainer script
+# lands here, and apt refuses to install anything else until dpkg finishes.
+package_install_interrupted() {
+  case "$(package_status "$1")" in
+    unpacked | half-configured | half-installed | triggers-awaited | triggers-pending)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# Finishes a dpkg run that an earlier bootstrap left unfinished, so that a rerun
+# resumes it instead of reading its own half-installed packages as foreign ones.
+resume_interrupted_repository_packages() {
+  local repository_name
+  local package_name
+  local package_names=()
+  local interrupted_packages=()
+
+  for repository_name in "${repository_names[@]}"; do
+    repository_enabled "${repository_name}" || continue
+    read -r -a package_names <<< "${repository_package_names[$repository_name]}"
+    for package_name in "${package_names[@]}"; do
+      package_install_interrupted "${package_name}" &&
+        interrupted_packages+=("${package_name}")
+    done
+  done
+  (( ${#interrupted_packages[@]} > 0 )) || return 0
+
+  printf 'Completing the interrupted installation of %s\n' "${interrupted_packages[*]}"
+  sudo env DEBIAN_FRONTEND=noninteractive dpkg --configure --pending ||
+    fail "dpkg could not finish installing ${interrupted_packages[*]}; resolve the package error above, then rerun chezmoi apply"
+  for package_name in "${interrupted_packages[@]}"; do
+    package_installed "${package_name}" ||
+      fail "${package_name} is still $(package_status "${package_name}") after dpkg finished the interrupted run"
+  done
 }
 
 installed_package_available_from_repository() {
@@ -358,6 +409,7 @@ fail_on_unmanaged_repository() {
   local command_bindings=()
   local command_name
   local command_package
+  local command_path
 
   read -r -a package_names <<< "${repository_package_names[$repository_name]}"
   read -r -a command_bindings <<< "${repository_command_bindings[$repository_name]}"
@@ -391,12 +443,14 @@ fail_on_unmanaged_repository() {
       command_name="${command_binding%%:*}"
       command_package="${command_binding#*:}"
       if command -v "${command_name}" >/dev/null 2>&1; then
+        command_path="$(command -v "${command_name}")"
         if ! package_installed "${command_package}"; then
-          printf 'error: %s resolves to an unmanaged command\n' "${command_name}" >&2
+          printf 'error: %s resolves to %s while the managed %s package is %s\n' \
+            "${command_name}" "${command_path}" "${command_package}" \
+            "$(package_status "${command_package}")" >&2
           return 1
         fi
         if ! command_owned_by_package "${command_name}" "${command_package}"; then
-          command_path="$(command -v "${command_name}")"
           printf 'error: %s resolves to %s, which is not owned by the managed package\n' \
             "${command_name}" "${command_path}" >&2
           return 1

--- a/tests/test-install-ubuntu-packages.sh
+++ b/tests/test-install-ubuntu-packages.sh
@@ -83,7 +83,19 @@ dpkg() {
     printf 'amd64\n'
   elif [[ "$1" == "--compare-versions" ]]; then
     command dpkg "$@"
+  elif [[ "$*" == "--configure --pending" ]]; then
+    printf '%s\n' "$*" >> "$test_root/dpkg.log"
+    ONEPASSWORD_STATUS=installed
   fi
+}
+sudo() {
+  "$@"
+}
+env() {
+  while [[ "${1:-}" == *=* ]]; do
+    shift
+  done
+  "$@"
 }
 dpkg-query() {
   if [[ "$1" == "-S" ]]; then
@@ -99,7 +111,14 @@ dpkg-query() {
     return
   fi
   case "${*: -1}" in
-    code|google-chrome-stable|gh|mise|1password|1password-cli)
+    1password)
+      if [[ "$*" == *'${Version}'* ]]; then
+        printf '8.12.26\n'
+      else
+        printf '%s\n' "${ONEPASSWORD_STATUS:-installed}"
+      fi
+      ;;
+    code|google-chrome-stable|gh|mise|1password-cli)
       if [[ "$*" == *'${Version}'* ]]; then
         printf '8.12.26\n'
       else
@@ -141,7 +160,7 @@ readlink() {
     -f\ code) printf '/usr/bin/code\n' ;;
     -f\ google-chrome) printf '/usr/bin/google-chrome\n' ;;
     -f\ gh) printf '/usr/bin/gh\n' ;;
-    -f\ 1password|*/usr/bin/1password) printf '/opt/1Password/1password\n' ;;
+    *1password) printf '/opt/1Password/1password\n' ;;
     -f\ op|*/usr/bin/op) printf '/usr/bin/op\n' ;;
     *) command readlink "$@" ;;
   esac
@@ -159,7 +178,8 @@ gh() {
 # delegate to the real command with `command dpkg "$@"`, which a stub of the same
 # name on PATH cannot do without calling itself, and the preflight run below
 # depends on a function outranking the PATH entry it shadows.
-export -f dpkg dpkg-query apt-cache snap flatpak onepassword op readlink code google-chrome gh
+export -f dpkg dpkg-query apt-cache snap flatpak onepassword op readlink code google-chrome gh \
+  sudo env
 
 output="$(run_preflight)"
 [[ "$output" == *"Adopting the existing official 1Password Stable apt installation"* ]]
@@ -173,6 +193,22 @@ if APT_ORIGIN="https://packages.example.invalid" run_preflight >"$test_root/conf
   exit 1
 fi
 grep -Fq 'is unavailable from the official stable repository' "$test_root/conflicting.out"
+
+# A bootstrap that failed while dpkg configured 1Password leaves the desktop
+# command on PATH with the package unpacked but not installed. A rerun finishes
+# that dpkg run instead of rejecting the command it left behind.
+ln -s /bin/true "$test_root/bin/1password"
+interrupted_output="$(ONEPASSWORD_STATUS=half-configured run_preflight)"
+[[ "$interrupted_output" == *"Completing the interrupted installation of 1password"* ]]
+test_assert_file_contains '--configure --pending' "$test_root/dpkg.log"
+
+if ONEPASSWORD_STATUS=not-installed run_preflight >"$test_root/foreign.out" 2>&1; then
+  printf 'error: a 1password command without a managed package was accepted\n' >&2
+  exit 1
+fi
+grep -Fq '1password resolves to' "$test_root/foreign.out"
+grep -Fq 'not-installed' "$test_root/foreign.out"
+rm "$test_root/bin/1password"
 
 ln -s /bin/true "$test_root/bin/op"
 export -n -f op

--- a/tests/test-ubuntu-package-foundation.sh
+++ b/tests/test-ubuntu-package-foundation.sh
@@ -10,8 +10,12 @@ set -euo pipefail
 . "$(dirname -- "${BASH_SOURCE[0]}")/fixture.sh"
 test_setup "$@"
 foundation_source="$(test_render_template 'home/.chezmoitemplates/ubuntu-package-foundation.sh')"
+# Every script that includes the package foundation includes the shell foundation
+# ahead of it, so the module's own diagnostics are available here too.
+shell_foundation_source="$(test_render_template 'home/.chezmoitemplates/shell-foundation.sh')"
 curl_log="${test_root}/curl.log"
 
+source "$shell_foundation_source"
 source "$foundation_source"
 
 repository_uris[chrome]='https://dl.google.com/linux/chrome/deb/'
@@ -200,3 +204,47 @@ if fail_on_unmanaged_repository onepassword > "$test_root/conflict.out" 2>&1; th
   exit 1
 fi
 grep -Fq 'conflicting apt repository' "$test_root/conflict.out"
+
+# A bootstrap interrupted while dpkg configured 1Password leaves the package
+# unpacked, which a rerun has to finish rather than read as a foreign install.
+onepassword_status=half-configured
+dpkg_configure_calls=0
+dpkg-query() {
+  if [[ "$1" == "-W" && "$*" == *'${db:Status-Status}'* ]]; then
+    if [[ "${*: -1}" == "1password" ]]; then
+      printf '%s\n' "$onepassword_status"
+    else
+      printf 'installed\n'
+    fi
+  elif [[ "$1" == "-W" && "$*" == *'${Version}'* ]]; then
+    printf '8.12.26\n'
+  else
+    return 1
+  fi
+}
+env() {
+  while [[ "${1:-}" == *=* ]]; do
+    shift
+  done
+  "$@"
+}
+dpkg() {
+  [[ "$*" == "--configure --pending" ]] || return 1
+  dpkg_configure_calls=$((dpkg_configure_calls + 1))
+  onepassword_status=installed
+}
+
+package_install_interrupted 1password
+resume_interrupted_repository_packages
+(( dpkg_configure_calls == 1 ))
+package_installed 1password
+
+onepassword_status=half-configured
+dpkg() {
+  return 1
+}
+if (resume_interrupted_repository_packages) > "$test_root/interrupted.out" 2>&1; then
+  printf 'error: a dpkg run that could not be finished was accepted\n' >&2
+  exit 1
+fi
+grep -Fq 'dpkg could not finish installing 1password' "$test_root/interrupted.out"


### PR DESCRIPTION
A bootstrap that failed while dpkg was configuring 1Password left the
package unpacked: its command resolved while dpkg still reported the
package as half-configured, so every rerun failed the unmanaged-command
guard before reaching the apt step that would have repaired the state the
guard was rejecting.

Read dpkg's status word in one place, name the states where an install
began but never finished, and finish that dpkg run before anything judges
the machine. The guard now reports the resolved path and the dpkg status,
so the next occurrence diagnoses itself.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
